### PR TITLE
GET 파라미터로 아희 코드를 넘길 수 있도록 수정

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,7 +54,7 @@
             <textarea id="machine-status" cols="30" rows="10"></textarea>
         </div>
     </div>
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
     <script src="https://cdn.jsdelivr.net/clipboard.js/1.5.12/clipboard.min.js"></script>
     <script type="text/javascript" src="one-color/one-color.js"></script>
     <script type="text/javascript" src="naheui/aheui.js"></script>

--- a/index.html
+++ b/index.html
@@ -103,7 +103,13 @@
         });
         $('#code-area').mouseleave(highlightCurrentMachineState);
         $(function () { // init
-            $('#mode-edit').click();
+            if (urlParam('content')) {
+                $('#editor textarea').text(decodeURI(urlParam('content')));
+                $('#mode-exec').click();
+                runMachine();
+            }
+            else
+                $('#mode-edit').click();
         });
         function initMachine() {
             stopMachine();
@@ -344,6 +350,16 @@
             }
             return result;
         }
+        function urlParam(name){
+            var results = new RegExp('[\?&]' + name + '=([^&#]*)').exec(window.location.href);
+            if (results == null){
+               return null;
+            }
+            else{
+               return results[1] || 0;
+            }
+        }
+
     </script>
     <style type="text/css">
         @import url('http://fonts.googleapis.com/earlyaccess/nanumgothic.css');

--- a/index.html
+++ b/index.html
@@ -14,6 +14,15 @@
     <div>
         <button id="mode-edit">편집모드</button>
         <button id="mode-exec">실행모드</button>
+        <button id="share-content">공유</button>
+        <div class="share-input-group" style="display:none">
+            <input id="share-input-link" type="text" value="">
+            <span class="input-group-button">
+                <button class="share-btn" type="button" data-clipboard-demo="" data-clipboard-target="#share-input-link">
+                복사
+                </button>
+            </span>
+        </div>
         <div id="editor">
 <textarea cols="50" rows="20">
 아밣밞따맣밫밗따붒
@@ -46,6 +55,7 @@
         </div>
     </div>
     <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/clipboard.js/1.5.12/clipboard.min.js"></script>
     <script type="text/javascript" src="one-color/one-color.js"></script>
     <script type="text/javascript" src="naheui/aheui.js"></script>
     <script type="text/javascript">
@@ -101,10 +111,17 @@
             render();
             initMachine();
         });
+        $('#share-content').click(function () {
+            $('.share-input-group').show();
+            var url = [location.protocol, '//', location.host, location.pathname].join('');
+            url += '?' + $.param({ content : b64EncodeUnicode($('#editor textarea').val()) });
+            $('#share-input-link').val(url);
+        });
         $('#code-area').mouseleave(highlightCurrentMachineState);
         $(function () { // init
+            new Clipboard('.share-btn');
             if (urlParam('content')) {
-                $('#editor textarea').text(decodeURI(urlParam('content')));
+                $('#editor textarea').val(b64DecodeUnicode(urlParam('content')));
                 $('#mode-exec').click();
                 runMachine();
             }
@@ -358,6 +375,17 @@
             else{
                return results[1] || 0;
             }
+        }
+        function b64EncodeUnicode(str) {
+            return btoa(encodeURIComponent(str).replace(/%([0-9A-F]{2})/g, function(match, p1) {
+                return String.fromCharCode('0x' + p1);
+            }));
+        }
+        function b64DecodeUnicode(str) {
+            str = decodeURIComponent(str);
+            return decodeURIComponent(Array.prototype.map.call(atob(str), function(c) {
+                return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2);
+            }).join(''));
         }
 
     </script>


### PR DESCRIPTION
안녕하세요 😄 avis 애용자중 한명으로서 기능 하나를 추가했으면 어떨까 해서 PR을 드립니다.
요지는 http://codepad.org 나 http://codecrap.com 같이 SNS에 코드를 공유할 수 있는 기능을 넣고 싶었습니다.
- 사용법
  - ![image](https://cloud.githubusercontent.com/assets/1228030/18604629/9e89fdac-7cb9-11e6-9967-7724a605da2d.png)
  - `https://aheui.github.io/avis/?content=(base64로_인코딩된_아희코드)`
  - sample : https://harunene.github.io/avis
- 사용 예
  - http://tinyurl.com/jhjbsjq
  - http://tinyurl.com/h9bvy33
- 어지간한 코드는 **곧바로** 트위터에 올릴 수 없습니다. 
  - 사용해보시면 알지만 트위터 텍스트 길이 한계때문에...
  - 코드 자체를 압축하는 방법도 시도해 보았으나 text 압축 라이브러리인 lz-string[[demo](http://pieroxy.net/blog/pages/lz-string/demo.html)] 를 이용해도 90자의 코드가 200자가 넘는 영문자로 변환되기 때문에 의미없는 것 같아 뺐습니다. 
  - 일단은 트위터에 공유하기 위해서는 공유버튼 누른 후 생기는 링크를 사용자가 직접 **tinyurl**이나 **bitly** 등의 url shortener 사이트를 이용해서 줄이는 것 말고는 답이 없어 보입니다.
