### PR TITLE
#1 복사 붙여넣기 구현

### DIFF
--- a/src/appState.js
+++ b/src/appState.js
@@ -615,6 +615,9 @@ class CodeSpace extends Array {
                     return codeLine;
                 });
                 this.splice(rowIndex + i, 0, ...codeLineAppends);
+                if (colIndex + textWidth > this._width) {
+                    this._width = colIndex + textWidth;
+                }
             }
         });
     }

--- a/src/appState.js
+++ b/src/appState.js
@@ -348,9 +348,9 @@ class CodeLine extends Array {
         }
         return result;
     }
-    isEmptyAfter(index, ignoreChars) {
+    isEmptyAfter(index, spaceChars) {
         for (let i = index; i < this.length; ++i) {
-            if (!ignoreChars.includes(this[i].char)) {
+            if (!spaceChars.has(this[i].char)) {
                 return false;
             }
         }
@@ -528,8 +528,8 @@ class CodeSpace extends Array {
     }
     insertChunk(rowIndex, colIndex, text, spaceFillChar, pushDown, overwrite) {
         // TODO 테스트 작성?
-        // TODO ignoreChars 딴 곳으로 옮기기
-        const ignoreChars = [spaceFillChar, ' '];
+        // TODO spaceChars 딴 곳으로 옮기기
+        const spaceChars = new Set([spaceFillChar, ' ']);
         // 덮어쓰기 모드라면 insert를 그대로 적용해도 무방함
         if (overwrite) {
             return this.insert(
@@ -555,7 +555,7 @@ class CodeSpace extends Array {
                 this.ensureHeight(rowIndex + 1);
                 boundWidth = 0;
                 // 첫 줄이 비어있으면 그냥 그대로 덮어쓰고, 아니면 새로 만듦
-                if (this[rowIndex].isEmptyAfter(colIndex, ignoreChars)) {
+                if (this[rowIndex].isEmptyAfter(colIndex, spaceChars)) {
                     this[rowIndex].ensureLength(colIndex, spaceFillChar);
                     boundHeight = 1;
                 } else {
@@ -576,7 +576,7 @@ class CodeSpace extends Array {
                         let code = codeLine[j + colIndex];
                         // 해당 열에 Code가 무시할 글자가 아니면 그 구간부터 가로로
                         // 밀어냄
-                        if (!ignoreChars.includes(code.char)) {
+                        if (!spaceChars.has(code.char)) {
                             if (j < boundWidth) boundWidth = j;
                             break;
                         }
@@ -623,8 +623,8 @@ class CodeSpace extends Array {
         });
     }
     insertChunkSmart(rowIndex, colIndex, text, spaceFillChar, overwrite) {
-        // TODO ignoreChars 딴 곳으로 옮기기
-        const ignoreChars = [spaceFillChar, ' '];
+        // TODO spaceChars 딴 곳으로 옮기기
+        const spaceChars = new Set([spaceFillChar, ' ']);
         const textLines = text.split(/\r?\n/);
         // 첫째 행이 해당 열부터 비어있다면:
         // 적용될 행들이 해당 열부터 비어있는지 여부를 검사하고 비어있다면
@@ -633,7 +633,7 @@ class CodeSpace extends Array {
         let pushDown = true;
         for (let i = 0; i < textLines.length; ++i) {
             const codeLine = this[i + rowIndex];
-            if (codeLine != null && !codeLine.isEmptyAfter(colIndex, ignoreChars)) {
+            if (codeLine != null && !codeLine.isEmptyAfter(colIndex, spaceChars)) {
                 pushDown = i !== 0;
                 break;
             } else {

--- a/src/appState.js
+++ b/src/appState.js
@@ -562,6 +562,7 @@ class CodeSpace extends Array {
                     boundHeight = 0;
                 }
             } else {
+                this.ensureHeight(rowIndex);
                 boundHeight = Math.min(this.length - rowIndex, textLines.length);
                 for (i = 0; i < boundHeight; ++i) {
                     const textLine = textLines[i];

--- a/src/appState.js
+++ b/src/appState.js
@@ -624,12 +624,20 @@ class CodeSpace extends Array {
     insertChunkSmart(rowIndex, colIndex, text, spaceFillChar, overwrite) {
         // TODO ignoreChars 딴 곳으로 옮기기
         const ignoreChars = [spaceFillChar, ' '];
-        // 해당 행이 해당 열부터 비어있는지 여부를 검사하고 비어있다면
-        // 아래로 내리고, 아니라면 오른쪽으로 밈
-        const codeLine = this[rowIndex];
+        const textLines = text.split(/\r?\n/);
+        // 첫째 행이 해당 열부터 비어있다면:
+        // 적용될 행들이 해당 열부터 비어있는지 여부를 검사하고 비어있다면
+        // 오른쪽으로 밀고, 아니면 아래로 내림
+        // 첫째 행이 비어있지 않으면 그냥 오른쪽으로 밂
         let pushDown = true;
-        if (codeLine != null && !codeLine.isEmptyAfter(colIndex, ignoreChars)) {
-            pushDown = false;
+        for (let i = 0; i < textLines.length; ++i) {
+            const codeLine = this[i];
+            if (codeLine != null && !codeLine.isEmptyAfter(colIndex, ignoreChars)) {
+                pushDown = i !== 0;
+                break;
+            } else {
+                pushDown = i === 0;
+            }
         }
         return this.insertChunk(
             rowIndex,

--- a/src/appState.js
+++ b/src/appState.js
@@ -632,7 +632,7 @@ class CodeSpace extends Array {
         // 첫째 행이 비어있지 않으면 그냥 오른쪽으로 밂
         let pushDown = true;
         for (let i = 0; i < textLines.length; ++i) {
-            const codeLine = this[i];
+            const codeLine = this[i + rowIndex];
             if (codeLine != null && !codeLine.isEmptyAfter(colIndex, ignoreChars)) {
                 pushDown = i !== 0;
                 break;

--- a/src/appState.js
+++ b/src/appState.js
@@ -412,8 +412,16 @@ class CodeLine extends Array {
             this[i].rotateCCW();
         }
     }
-    toString() {
-        return this.map(code => code.toString()).join('');
+    toString(selection) {
+        // selection이 없으면 전체를 뱉음
+        if (selection == null) {
+            return this.map(code => code.toString()).join('');
+        }
+        // 아니라면 selection의 left / right만큼 잘라서 보내줌
+        // right는 exclusive한 인덱스라서 1만큼 더해야 slice에서 쓸 수 있음
+        return this.slice(selection.left, selection.right + 1).map(
+            code => code.toString()
+        ).join('');
     }
 }
 
@@ -650,8 +658,16 @@ class CodeSpace extends Array {
     toggleBreakPoint(x, y) {
         // TODO
     }
-    toString() {
-        return this.map(line => line.toString()).join('\n');
+    toString(selection) {
+        // 선택 영역을 지정하지 않았으면 코드 전체를 뱉음
+        if (selection == null) {
+            return this.map(line => line.toString()).join('\n');
+        }
+        // right / bottom은 exclusive 인덱스라서 slice에다가 쓰려면 1을
+        // 더해야 함
+        return this.slice(selection.top, selection.bottom + 1).map(
+            line => line.toString(selection)
+        ).join('\n');
     }
     static fromText(text) {
         const lines = text.split(/\r?\n/g);

--- a/src/appState.js
+++ b/src/appState.js
@@ -552,7 +552,7 @@ class CodeSpace extends Array {
             let i;
             // 가로는 밀어낼 길이를 알아내기 위해서 검사를 두 번 돌아야 함...
             if (pushDown) {
-                this.ensureHeight(rowIndex);
+                this.ensureHeight(rowIndex + 1);
                 boundWidth = 0;
                 // 첫 줄이 비어있으면 그냥 그대로 덮어쓰고, 아니면 새로 만듦
                 if (this[rowIndex].isEmptyAfter(colIndex, ignoreChars)) {

--- a/src/components/CodeSpace/index.jsx
+++ b/src/components/CodeSpace/index.jsx
@@ -618,11 +618,11 @@ function handleInputPaste(
         0
     );
     const pasteHeight = pasteLines.length;
-    appState.insertCode(
+    appState.insertChunkCode(
         appState.selection.y,
         appState.selection.x + inputLength,
         pasteValue,
-        true
+        overwriteMode
     );
     // 입력한 뒤 붙여넣은 텍스트를 선택 (엑셀의 동작)
     appState.selection = {

--- a/src/components/CodeSpace/index.jsx
+++ b/src/components/CodeSpace/index.jsx
@@ -620,6 +620,14 @@ function handleInputPaste(
         0
     );
     const pasteHeight = pasteLines.length;
+    if (!appState.selection.isCaret) {
+      appState.peelCode(
+          appState.selection.y,
+          appState.selection.x + inputLength,
+          appState.selection.width,
+          appState.selection.height,
+      );
+    }
     appState.insertChunkCode(
         appState.selection.y,
         appState.selection.x + inputLength,

--- a/src/components/CodeSpace/index.jsx
+++ b/src/components/CodeSpace/index.jsx
@@ -628,7 +628,7 @@ function handleInputPaste(
           appState.selection.height,
       );
     }
-    appState.insertChunkCode(
+    appState.insertChunkSmartCode(
         appState.selection.y,
         appState.selection.x + inputLength,
         pasteValue,

--- a/src/components/CodeSpace/index.jsx
+++ b/src/components/CodeSpace/index.jsx
@@ -342,12 +342,9 @@ export default connect(
                     );
                 }}
                 onPaste={e => {
-                    // 다른 브라우저들과 파이어폭스 22+에서 지원하고 있어서
-                    // 파이어폭스 22 미만을 지원하려면 다른 방법도 구현해야 함
-                    let clipboardData, pastedData;
+                    const clipboardData = e.clipboardData || window.clipboardData;
+                    const pastedData = clipboardData.getData('Text');
                     e.preventDefault();
-                    clipboardData = e.clipboardData || window.clipboardData;
-                    pastedData = clipboardData.getData('Text');
                     handleInputPaste(
                         this.inputElement.value,
                         pastedData,

--- a/src/components/CodeSpace/index.jsx
+++ b/src/components/CodeSpace/index.jsx
@@ -601,10 +601,6 @@ function handleInputPaste(
     resetCaretAnimation,
     scrollToFocus,
 ) {
-    // 밀어쓰기 모드의 경우 붙여넣을 영역이 전부 빈 공간인지 확인하고,
-    // 빈 공간이라면 해당 공간에 그대로 덮어쓰면 됨
-    // 아니라면 붙여넣을 영역을 확보하기 위해 행과 열을 밀어낸 뒤 덮어 씀
-    // 덮어쓰기 모드에서는 그대로 덮어쓰면 됨
     // 외부에서 가지고 올 때 \n은 자르되 공백은 자르면 안되므로 따로
     // 정규표현식으로 처리함
     const inputValue = inputValueUntrimmed.replace(/^[\r\n]+|[\r\n]+$/, '');
@@ -633,13 +629,13 @@ function handleInputPaste(
     );
     // 입력한 뒤 붙여넣은 텍스트를 선택 (엑셀의 동작)
     appState.selection = {
-        anchor: {
-            y: appState.selection.y + pasteHeight - 1,
-            x: appState.selection.x + inputLength + pasteWidth - 1,
-        },
         focus: {
             y: appState.selection.y,
             x: appState.selection.x + inputLength,
+        },
+        anchor: {
+            y: appState.selection.y + pasteHeight - 1,
+            x: appState.selection.x + inputLength + pasteWidth - 1,
         }
     };
     clearInputValue();

--- a/src/components/CodeSpace/index.jsx
+++ b/src/components/CodeSpace/index.jsx
@@ -350,7 +350,7 @@ export default connect(
                     pastedData = clipboardData.getData('Text');
                     handleInputPaste(
                         this.inputElement.value,
-                        pastedData.trim(),
+                        pastedData,
                         appState,
                         () => this.clearInputValue(),
                         () => this.resetCaretAnimation(),
@@ -597,7 +597,7 @@ function handleInputCut(
 }
 
 function handleInputPaste(
-    inputValue,
+    inputValueUntrimmed,
     pasteValue,
     appState, 
     clearInputValue,
@@ -608,7 +608,9 @@ function handleInputPaste(
     // 빈 공간이라면 해당 공간에 그대로 덮어쓰면 됨
     // 아니라면 붙여넣을 영역을 확보하기 위해 행과 열을 밀어낸 뒤 덮어 씀
     // 덮어쓰기 모드에서는 그대로 덮어쓰면 됨
-    // TODO: 밀어쓰기 모드에서의 빈 공간 확보
+    // 외부에서 가지고 올 때 \n은 자르되 공백은 자르면 안되므로 따로
+    // 정규표현식으로 처리함
+    const inputValue = inputValueUntrimmed.replace(/^[\r\n]+|[\r\n]+$/, '');
     const inputLength = inputValue.length;
     const { inputMethod } = appState.editOptions;
     const overwriteMode = inputMethod === 'overwrite';


### PR DESCRIPTION
자르기/복사/붙여넣기를 구현했습니다.

근데 붙여넣기 알고리즘이 너무 복잡해서 `codeSpace.insertChunk`라는 함수를 만들어서 처리했는데 원래 가로/세로를 알아서 자동으로 필요한 공간만큼 밀어내게 만들었는데 일관성이 없어서

1. 가로로 밀 때에는 알아서 밀어낼 영역을 판단해서 사각형 영역을 보존한 채로 오른쪽에 있는 코드들을 필요한 만큼만 밀어냅니다
2. 세로로 밀 때에는 해당 줄이 선택 영역 이후로 비어있다면 그냥 거기다가 붙여넣고 아니라면 새 줄을 만듭니다

가 되게 고쳤고, `codeSpace.insertChunkSmart`는 알아서 코드를 붙여넣을 방향을 선택하는 함수인데 해당 줄이 선택 영역 이후로 비어있다면 세로로 붙이고 아니라면 가로로 붙여넣습니다